### PR TITLE
prevent full page reloading when updating sass or stylus

### DIFF
--- a/gulpset/tasks/sass.off/index.js
+++ b/gulpset/tasks/sass.off/index.js
@@ -40,5 +40,5 @@ gulpset.tasks.sass = function(doMinify, browsers, conf) {
 		.pipe(postcss([autoprefixer({browsers: conf.browsers})]))
 		.pipe(gulpif(doMinify !== true, sourcemaps.write("./")))
 		.pipe(gulp.dest(conf.dest))
-		.pipe(gulpset.stream());
+		.pipe(gulpset.stream({match: '**/*.css'}));
 };

--- a/gulpset/tasks/stylus.off/index.js
+++ b/gulpset/tasks/stylus.off/index.js
@@ -41,5 +41,5 @@ gulpset.tasks.stylus = function(doMinify, browsers, conf) {
 		.pipe(postcss([autoprefixer({browsers: conf.browsers})]))
 		.pipe(gulpif(doMinify !== true, sourcemaps.write("./")))
 		.pipe(gulp.dest(conf.dest))
-		.pipe(gulpset.stream());
+		.pipe(gulpset.stream({match: '**/*.css'}));
 };


### PR DESCRIPTION
When updating sass or stylus, both injecting CSS and full page reloading occurs.
To prevent the latter, I added `{match: '**/*.css'}` to `stream()`'s option.

(cf. https://www.browsersync.io/docs/gulp#gulp-sass-maps )